### PR TITLE
add current scroll position to bounding client rect top

### DIFF
--- a/src/hooks/useScrollTo.ts
+++ b/src/hooks/useScrollTo.ts
@@ -3,7 +3,10 @@ import { useRef, useCallback, Ref, RefObject } from 'react';
 export function useScrollTo<T extends Element>(ref: RefObject<T>): () => void {
   const scrollTo = useCallback(() => {
     if (ref.current) {
-      window.scrollTo(0, ref.current.getBoundingClientRect().top);
+      window.scrollTo(
+        0,
+        ref.current.getBoundingClientRect().top + window.scrollY
+      );
     }
   }, [ref, ref.current]);
   return scrollTo;


### PR DESCRIPTION
bounding client rect depends on viewport, isn't absolute. Adding scrollY makes it absoute.